### PR TITLE
Added error handling if user is not in the directory

### DIFF
--- a/commands/helpers.js
+++ b/commands/helpers.js
@@ -5,6 +5,9 @@ const getRoles = async (email) => {
     const user = members.find((value) => {
         return value.email == email
     });
+    if (!user) {
+        return null;
+    }
     return user.status
 }
 
@@ -16,8 +19,8 @@ const getMember = (client, userId) => {
 
 const updateUserRoles = async (email, user_id, client) => {
     const role_to_assign = await getRoles(email);
-    if (role_to_assign === '') {
-        return role_to_assign;
+    if (!role) {
+        return null;
     }
     const member = getMember(client, user_id);
     const role = member.guild.roles.cache.find(role => role.name === role_to_assign);

--- a/commands/verify.js
+++ b/commands/verify.js
@@ -14,6 +14,9 @@ const verify = async (code, user_id, client) => {
     }
     const email = userVerification.email;
     const role = await updateUserRoles(email, user_id, client);
+    if (!role) {
+        return 'not-a-member';
+    }
     addVerifiedUser(user_id, email, role);
     await verification.deleteOne(doc);
     return 'success';

--- a/index.js
+++ b/index.js
@@ -84,6 +84,10 @@ client.on('interactionCreate', async interaction => {
 			await interaction.reply('Entered incorrect verification code, please try again');
 			return;
 		}
+		else if (res === 'not-a-member') {
+			await interaction.reply('You are not in the DataRes directory.  If this is a mistake, please contact Colin Curtis');
+			return;
+		}
 		await interaction.reply('Successfully verified your account');
 	}
 	else if (commandName === 'update-roles') {

--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ client.on('interactionCreate', async interaction => {
 			return;
 		}
 		else if (res === 'not-a-member') {
-			await interaction.reply('You are not in the DataRes directory.  If this is a mistake, please contact Colin Curtis');
+			await interaction.reply('You are not in the DataRes directory.  If this is a mistake, please contact leadership');
 			return;
 		}
 		await interaction.reply('Successfully verified your account');


### PR DESCRIPTION
Should address issues relating to a user not being in the DataRes directory.

In the future, we will verify emails without looking up club members in the directory and assigning roles, but for now we'll let it slide so that we don't have to worry about people being confused by the new way of doing things.