### PR TITLE
Add update-all command

### DIFF
--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -4,8 +4,18 @@ const updateRoles = require("./update_roles");
 const verify = require("./verify");
 const whoami = require("./whoami");
 const datalearn = require("./datalearn");
+const updateAll = require("./update_all");
+const updateSheet = require("./update_sheet");
 
-const commands = [iam, updateRoles, verify, whoami, datalearn];
+const commands = [
+  iam,
+  updateRoles,
+  verify,
+  whoami,
+  datalearn,
+  updateAll,
+  updateSheet,
+];
 
 module.exports = (client) => {
   // Collate commands into Collection

--- a/src/commands/read_sheet.js
+++ b/src/commands/read_sheet.js
@@ -4,7 +4,7 @@ const API_KEY = process.env.GOOGLE_API_KEY;
 const SHEET_ID = process.env.SHEET_ID;
 const SHEET_GID = process.env.SHEET_GID;
 
-const readSheet = async () => {
+async function updateSheet() {
   const doc = new GoogleSpreadsheet(SHEET_ID);
   doc.useApiKey(API_KEY);
   // https://theoephraim.github.io/node-google-spreadsheet/#/classes/google-spreadsheet-worksheet
@@ -16,7 +16,9 @@ const readSheet = async () => {
   for (const row of rows) {
     data.push({ name: row.Name, email: row.Email, status: row.Status });
   }
-  return data;
-};
+  global.sheetData = data;
+}
 
-module.exports = readSheet;
+updateSheet();
+
+module.exports = { updateSheet };

--- a/src/commands/update_all.js
+++ b/src/commands/update_all.js
@@ -1,9 +1,8 @@
-const { SlashCommandBuilder } = require("discord.js");
+const { SlashCommandBuilder, PermissionFlagsBits } = require("discord.js");
 const db = require("../db");
 const { updateUserFromSheet } = require("./helpers");
 
 async function execute(interaction) {
-  // TODO: Make admin only
   const users = db.collection("users").find();
   const ids_in_guild = (await interaction.guild.members.fetch()).map(
     (member) => member.user.id
@@ -14,11 +13,17 @@ async function execute(interaction) {
       updateUserFromSheet(doc.email, doc.user_id, interaction.client);
     }
   });
+
+  interaction.reply({
+    content: "Updating users...",
+    ephemeral: true,
+  });
 }
 
 module.exports = {
   data: new SlashCommandBuilder()
     .setName("update-all")
-    .setDescription("update all users team roles and names (ADMIN ONLY!)"),
+    .setDescription("update all users team roles and names (ADMIN ONLY!)")
+    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
   execute,
 };

--- a/src/commands/update_all.js
+++ b/src/commands/update_all.js
@@ -1,0 +1,24 @@
+const { SlashCommandBuilder } = require("discord.js");
+const db = require("../db");
+const { updateUserFromSheet } = require("./helpers");
+
+async function execute(interaction) {
+  // TODO: Make admin only
+  const users = db.collection("users").find();
+  const ids_in_guild = (await interaction.guild.members.fetch()).map(
+    (member) => member.user.id
+  );
+
+  users.forEach(async (doc) => {
+    if (doc && ids_in_guild.includes(doc.user_id)) {
+      updateUserFromSheet(doc.email, doc.user_id, interaction.client);
+    }
+  });
+}
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName("update-all")
+    .setDescription("update all users team roles and names (ADMIN ONLY!)"),
+  execute,
+};

--- a/src/commands/update_sheet.js
+++ b/src/commands/update_sheet.js
@@ -1,8 +1,7 @@
-const { SlashCommandBuilder } = require("discord.js");
+const { SlashCommandBuilder, PermissionFlagsBits } = require("discord.js");
 const { updateSheet } = require("./read_sheet");
 
 async function execute(interaction) {
-  // TODO: Make admin only
   await updateSheet();
   interaction.reply({
     content: "Sheet updated",
@@ -13,6 +12,7 @@ async function execute(interaction) {
 module.exports = {
   data: new SlashCommandBuilder()
     .setName("update-sheet")
-    .setDescription("update google sheet cached data (ADMIN ONLY!)"),
+    .setDescription("update google sheet cached data (ADMIN ONLY!)")
+    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
   execute,
 };

--- a/src/commands/update_sheet.js
+++ b/src/commands/update_sheet.js
@@ -1,0 +1,18 @@
+const { SlashCommandBuilder } = require("discord.js");
+const { updateSheet } = require("./read_sheet");
+
+async function execute(interaction) {
+  // TODO: Make admin only
+  await updateSheet();
+  interaction.reply({
+    content: "Sheet updated",
+    ephemeral: true,
+  });
+}
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName("update-sheet")
+    .setDescription("update google sheet cached data (ADMIN ONLY!)"),
+  execute,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,9 @@ const registerCommands = require("./commands");
 const SERVER_ID = process.env.SERVER_ID;
 
 // Create a new client instance
-const client = new Client({ intents: [GatewayIntentBits.Guilds] });
+const client = new Client({
+  intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMembers],
+});
 
 // When the client is ready, run this code (only once)
 client.once("ready", async () => {


### PR DESCRIPTION
Fixes #13.
Google sheet is now cached and update-sheet can be run to refresh it.
Also fixes error handling for updateUserFromSheet.

TODO: Make `/update-all` and `/update-sheet` only runnable by admins.